### PR TITLE
fix: remove double sanitization in language switcher

### DIFF
--- a/markup/components/header/language-switcher.js
+++ b/markup/components/header/language-switcher.js
@@ -80,7 +80,7 @@
             const value = getNestedValue(langData, key);
 
             if (value !== void 0) {
-                element.innerHTML = sanitize(value);
+                element.innerHTML = value;
             }
         });
 


### PR DESCRIPTION
## Problem
Translation strings were double-sanitized, causing `&amp;` to render as `&amp;amp;` in the browser.

## Root Cause
`sanitizeStrings()` escapes HTML entities when translations are loaded (line 63). A second `sanitize()` call on `innerHTML` assignment (line 83) re-escaped already-escaped entities.

## Fix
Removed the redundant `sanitize()` call in `applyTranslations()` — the data is already sanitized from load time.

## Before
```
Technical Leadership &amp; Mentorship
```

## After
```
Technical Leadership & Mentorship
```