### PR TITLE
feat: add employment section

### DIFF
--- a/markup/components/employment/data/data.js
+++ b/markup/components/employment/data/data.js
@@ -1,0 +1,68 @@
+const data = {
+    employment: {
+        title: {
+            en: 'Employment',
+            ru: 'Трудовая деятельность',
+            uk: 'Трудова діяльність'
+        },
+        description: {
+            en: 'Career history and professional engagements',
+            ru: 'История карьеры и профессиональная деятельность',
+            uk: 'Історія кар\'єри та професійна діяльність'
+        },
+        items: [
+            {
+                title: {
+                    en: 'Freelance Developer',
+                    ru: 'Фриланс-разработчик',
+                    uk: 'Фриланс-розробник'
+                },
+                company: {
+                    en: 'Self-employed',
+                    ru: 'Самозанятый',
+                    uk: 'Самозайнятий'
+                },
+                startDate: '2026',
+                endDate: null,
+                present: {
+                    en: 'present',
+                    ru: 'наст.',
+                    uk: 'наст.'
+                }
+            },
+            {
+                title: {
+                    en: 'Senior Magento 2 Developer',
+                    ru: 'Senior Magento 2 разработчик',
+                    uk: 'Senior Magento 2 розробник'
+                },
+                company: {
+                    en: 'StudioRaz',
+                    ru: 'StudioRaz',
+                    uk: 'StudioRaz'
+                },
+                location: {
+                    en: 'Israel',
+                    ru: 'Израиль',
+                    uk: 'Ізраїль'
+                },
+                startDate: '2017',
+                endDate: '2026'
+            },
+            {
+                title: {
+                    en: 'Freelance Developer',
+                    ru: 'Фриланс-разработчик',
+                    uk: 'Фриланс-розробник'
+                },
+                company: {
+                    en: 'Self-employed',
+                    ru: 'Самозанятый',
+                    uk: 'Самозайнятий'
+                },
+                startDate: '2015',
+                endDate: '2017'
+            }
+        ]
+    }
+};

--- a/markup/components/employment/employment.html
+++ b/markup/components/employment/employment.html
@@ -1,0 +1,28 @@
+<section class="section employment">
+    <h2 class="title section-title" data-i18n="employment.title">
+        {{t 'employment.title'}}
+    </h2>
+    <p class="desc" data-i18n="employment.description">
+        {{t 'employment.description'}}
+    </p>
+    <ul class="employment-list">
+        {{#with (lookup this "employment")}}
+        {{#each items}}
+        <li class="employment-item">
+            <div class="employment-header">
+                <h3 class="employment-title" data-i18n="employment.items.{{@index}}.title">{{{title.en}}}</h3>
+                <span class="employment-date">
+                    <time data-i18n-attr="datetime:employment.items.{{@index}}.startDate" datetime="{{startDate}}">{{startDate}}</time>
+                    {{#if endDate}} — <time data-i18n-attr="datetime:employment.items.{{@index}}.endDate" datetime="{{endDate}}">{{endDate}}</time>{{else}} — <span data-i18n="employment.items.{{@index}}.present">present</span>{{/if}}
+                </span>
+            </div>
+            {{#if company}}
+            <p class="employment-company" data-i18n="employment.items.{{@index}}.company">
+                {{{company.en}}}{{#if location}}, {{{location.en}}}{{/if}}
+            </p>
+            {{/if}}
+        </li>
+        {{/each}}
+        {{/with}}
+    </ul>
+</section>

--- a/markup/components/employment/employment.scss
+++ b/markup/components/employment/employment.scss
@@ -1,0 +1,35 @@
+.employment {
+    &-list {
+        @extend %section-list;
+    }
+
+    &-item {
+        @extend %section-list-item;
+    }
+
+    &-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 8px;
+        flex-wrap: wrap;
+    }
+
+    &-title {
+        @extend %section-list-item-title;
+        margin-bottom: 0;
+    }
+
+    &-date {
+        font-size: 13px;
+        color: var(--color-text-muted);
+        white-space: nowrap;
+        flex-shrink: 0;
+    }
+
+    &-company {
+        margin-top: 2px;
+        font-size: 14px;
+        color: var(--color-text-secondary);
+    }
+}

--- a/markup/components/sections/sections.html
+++ b/markup/components/sections/sections.html
@@ -3,7 +3,8 @@
     {{> hard-skills/hard-skills}}
 </aside>
 <div class="sections-main">
-    {{> soft-skills/soft-skills}}
+    {{> employment/employment}}
     {{> experience/experience}}
     {{> achievements/achievements}}
+    {{> soft-skills/soft-skills}}
 </div>

--- a/markup/static/scss/entry/partials/_components.scss
+++ b/markup/static/scss/entry/partials/_components.scss
@@ -8,4 +8,5 @@
 @import 'components/languages/languages';
 @import 'components/hard-skills/hard-skills';
 @import 'components/experience/experience';
+@import 'components/employment/employment';
 @import 'components/soft-skills/soft-skills';


### PR DESCRIPTION
## Summary

Adds a new Employment section before Experience in the main content area.

## Changes

- **New component:** `markup/components/employment/` with data.js, template, and SCSS
- **Section order:** Employment → Experience → Achievements → Soft Skills
- **Data structure:** Each item has title, company, location, structured startDate/endDate fields
- **Semantic markup:** `<time>` tags for dates, `datetime` attributes for machine-readable dates
- **Responsive:** Date aligned right on desktop, stacks on mobile

## Employment entries

| Title | Company | Location | Period |
|-------|---------|----------|--------|
| Freelance Developer | Self-employed | — | 2026 — present |
| Senior Magento 2 Developer | StudioRaz | Israel | 2017 — 2026 |
| Freelance Developer | Self-employed | — | 2015 — 2017 |